### PR TITLE
For IP-in-IP routes, use original next hop received in BGP UPDATE

### DIFF
--- a/nest/route.h
+++ b/nest/route.h
@@ -344,6 +344,7 @@ typedef struct rta {
   byte aflags;				/* Attribute cache flags (RTAF_...) */
   u16 hash_key;				/* Hash over important fields */
   u32 igp_metric;			/* IGP metric to next hop (for iBGP routes) */
+  ip_addr orig_gw;			/* Original next hop from BGP UPDATE */
   ip_addr gw;				/* Next hop */
   ip_addr from;				/* Advertising router */
   struct hostentry *hostentry;		/* Hostentry for recursive next-hops */

--- a/proto/bgp/packets.c
+++ b/proto/bgp/packets.c
@@ -1163,6 +1163,7 @@ bgp_set_next_hop(struct bgp_proto *p, rta *a)
       if (ipa_zero(*nexthop))
 	  return 0;
 
+      a->orig_gw = *nexthop;
       rta_set_recursive_next_hop(p->p.table, a, p->igp_table, nexthop, nexthop + second);
     }
 

--- a/sysdep/linux/netlink.c
+++ b/sysdep/linux/netlink.c
@@ -677,7 +677,7 @@ nl_send_route(struct krt_proto *p, rte *e, struct ea_list *eattrs, int new)
          * to the originator of the route.
          */
         nl_add_attr_u32(&r.h, sizeof(r), RTA_OIF, i->index);
-        nl_add_attr_ipa(&r.h, sizeof(r), RTA_GATEWAY, a->from);
+        nl_add_attr_ipa(&r.h, sizeof(r), RTA_GATEWAY, a->orig_gw);
         r.r.rtm_flags |= RTNH_F_ONLINK;
       }
       else


### PR DESCRIPTION
Instead of using a recursively resolved next hop, which will probably
be to somewhere half way along the tunnel, from where packets won't be
able to be routed any further.